### PR TITLE
Make ReceiveMessage() return the most recent matching message

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 ext.licenseFile = files("$rootDir/LICENSE.txt")
 
-def pubVersion = '2.1.0'
+def pubVersion = '2.2.0'
 
 def outputsFolder = file("$buildDir/allOutputs")
 

--- a/src/main/native/cpp/Drivers/CandleWinUSB/CandleWinUSBDevice.cpp
+++ b/src/main/native/cpp/Drivers/CandleWinUSB/CandleWinUSBDevice.cpp
@@ -140,7 +140,7 @@ CANStatus CandleWinUSBDevice::ReceiveCANMessage(std::shared_ptr<CANMessage>& msg
         if (
             CANBridge_ProcessMask({m.second->GetMessageId(), 0}, m.first)
             && CANBridge_ProcessMask({messageID, messageMask}, m.first)
-            && m.second->GetTimestampUs() > mostRecent->GetTimestampUs()
+            && (!mostRecent || m.second->GetTimestampUs() > mostRecent->GetTimestampUs())
         ) {
             mostRecent = m.second;
             status = CANStatus::kOk;

--- a/src/main/native/cpp/Drivers/CandleWinUSB/CandleWinUSBDevice.cpp
+++ b/src/main/native/cpp/Drivers/CandleWinUSB/CandleWinUSBDevice.cpp
@@ -137,7 +137,11 @@ CANStatus CandleWinUSBDevice::ReceiveCANMessage(std::shared_ptr<CANMessage>& msg
     m_thread.ReceiveMessage(messages);
     std::shared_ptr<CANMessage> mostRecent;
     for (auto& m : messages) {
-        if (CANBridge_ProcessMask({m.second->GetMessageId(), 0}, m.first) && CANBridge_ProcessMask({messageID, messageMask}, m.first)) {
+        if (
+            CANBridge_ProcessMask({m.second->GetMessageId(), 0}, m.first)
+            && CANBridge_ProcessMask({messageID, messageMask}, m.first)
+            && m.second->GetTimestampUs() > mostRecent->GetTimestampUs()
+        ) {
             mostRecent = m.second;
             status = CANStatus::kOk;
         }

--- a/src/main/native/cpp/Drivers/Serial/SerialDevice.cpp
+++ b/src/main/native/cpp/Drivers/Serial/SerialDevice.cpp
@@ -91,7 +91,11 @@ CANStatus SerialDevice::ReceiveCANMessage(std::shared_ptr<CANMessage>& msg, uint
     m_thread.ReceiveMessage(messages);
     std::shared_ptr<CANMessage> mostRecent;
     for (auto& m : messages) {
-        if (CANBridge_ProcessMask({m.second->GetMessageId(), 0}, m.first) && CANBridge_ProcessMask({messageID, messageMask}, m.first)) {
+        if (
+            CANBridge_ProcessMask({m.second->GetMessageId(), 0}, m.first)
+            && CANBridge_ProcessMask({messageID, messageMask}, m.first)
+            && m.second->GetTimestampUs() > mostRecent->GetTimestampUs()
+        ) {
             mostRecent = m.second;
             status = CANStatus::kOk;    
         }

--- a/src/main/native/cpp/Drivers/Serial/SerialDevice.cpp
+++ b/src/main/native/cpp/Drivers/Serial/SerialDevice.cpp
@@ -94,7 +94,7 @@ CANStatus SerialDevice::ReceiveCANMessage(std::shared_ptr<CANMessage>& msg, uint
         if (
             CANBridge_ProcessMask({m.second->GetMessageId(), 0}, m.first)
             && CANBridge_ProcessMask({messageID, messageMask}, m.first)
-            && m.second->GetTimestampUs() > mostRecent->GetTimestampUs()
+            && (!mostRecent || m.second->GetTimestampUs() > mostRecent->GetTimestampUs())
         ) {
             mostRecent = m.second;
             status = CANStatus::kOk;    

--- a/vendordeps/CANBridge.json
+++ b/vendordeps/CANBridge.json
@@ -1,7 +1,7 @@
 {
     "fileName": "CANBridge.json",
     "name": "CANBridge",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "uuid": "34b37c7c-8acc-405f-9631-d21f20dc59d8",
     "mavenUrls": [
         "http://www.revrobotics.com/content/sw/max/sdk/maven/"


### PR DESCRIPTION
Without this PR, `ReceiveMessage()` is only guaranteed to return the most recent matching CAN frame if the mask is all 1s (`0x1FFFFFFF`). Otherwise, it will pick the most recent frame for whichever of the fully-matching arbitration IDs it happens to iterate to first.

This PR is needed to make https://github.com/REVrobotics/Desktop-Factory-Tester/pull/45 work correctly under all circumstances.