### PR TITLE
Fix repeat frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ subsequent frames will be scheduled every 2 seconds. Note
 that any change to the data in the second call will not be
 sent, meaning the second call is essentially a no-op if a
 new call with different data is sent before the previous
-interval is up.
+interval is up. Sending a frame with an interval of -1
+will cancel the repeat, and not send the frame. Sending with
+an interval of 0 will schedule the new frame once, then stop
+repeating.
 
 ## Build Requirements
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,38 @@
 
 This repository is for the CANBridge software that is run on non-roboRIO platforms.
 
+## Behavior
+
+When sending a frame with a given interval, the behavior when
+setting a new interval is as follows:
+
+The first time a frame is scheduled with an interval, it
+will be sent at the next available time. The next instance
+of the same frame id will be sent after that interval, even
+if the interval has changed.
+
+See the following pseudo-example:
+
+```
+sendMessage(frame, 5000)
+delay(1000)
+
+updateFrameData(frame)
+sendMessage(frame, 1000)
+delay(500)
+
+updateFrameData(frame)
+sendMessage(frame, 2000)
+```
+
+In this case, the first frame will be scheduled immediately,
+the second will be scheduled 5 seconds later, and after that,
+subsequent frames will be scheduled every 2 seconds. Note
+that any change to the data in the second call will not be
+sent, meaning the second call is essentially a no-op if a
+new call with different data is sent before the previous
+interval is up.
+
 ## Build Requirements
 
 1. Git

--- a/src/main/native/include/rev/Drivers/CandleWinUSB/CandleWinUSBDeviceThread.h
+++ b/src/main/native/include/rev/Drivers/CandleWinUSB/CandleWinUSBDeviceThread.h
@@ -90,8 +90,8 @@ public:
     void stopRepeatedMessage(uint32_t messageId) {
         for (int i = 0; i < m_sendQueue.size(); i++) {
             detail::CANThreadSendQueueElement el = m_sendQueue.front();
-            m_sendQueue.pop();
-            if (el.m_msg.GetMessageId() != messageId) m_sendQueue.push(el);
+            m_sendQueue.pop_front();
+            if (el.m_msg.GetMessageId() != messageId) m_sendQueue.push_back(el);
         }
     }
 
@@ -204,23 +204,23 @@ private:
                     detail::CANThreadSendQueueElement el = m_sendQueue.front();
                     if (el.m_intervalMs == -1) {
                         while(m_sendQueue.size() > 0) {
-                            m_sendQueue.pop();
+                            m_sendQueue.pop_front();
                         }
                         continue;
                     }
 
                     auto now = std::chrono::steady_clock::now();
 
-                    m_sendQueue.pop();
+                    m_sendQueue.pop_front();
                     if (WriteMessages(el, now)) {
 
                         // Return to end of queue if repeated
                         if (el.m_intervalMs > 0 ) {
                             el.m_prevTimestamp = now;
-                            m_sendQueue.push(el);
+                            m_sendQueue.push_back(el);
                         }
                     } else {
-                        m_sendQueue.push(el);
+                        m_sendQueue.push_back(el);
                     }
                 }
             }

--- a/src/main/native/include/rev/Drivers/DriverDeviceThread.h
+++ b/src/main/native/include/rev/Drivers/DriverDeviceThread.h
@@ -91,6 +91,7 @@ public:
 
         if(existing) {
             existing->m_intervalMs = timeIntervalMs;
+            existing->m_msg = msg;
         } else {
             m_sendQueue.push_back(detail::CANThreadSendQueueElement(msg, timeIntervalMs));
         }

--- a/src/main/native/include/rev/Drivers/SerialPort/SerialDeviceThread.h
+++ b/src/main/native/include/rev/Drivers/SerialPort/SerialDeviceThread.h
@@ -272,7 +272,7 @@ private:
                 std::lock_guard<std::mutex> lock(m_writeMutex);
                 if (m_sendQueue.size() > 0) {
                     detail::CANThreadSendQueueElement el = m_sendQueue.front();
-                    m_sendQueue.pop();
+                    m_sendQueue.pop_front();
                     if (el.m_intervalMs == -1) {
                         continue;
                     }
@@ -285,7 +285,7 @@ private:
                         if (el.m_intervalMs > 0 ) {
                             el.m_prevTimestamp = now;
                             
-                            m_sendQueue.push(el);
+                            m_sendQueue.push_back(el);
                         }
                         doRead = true;
                     }


### PR DESCRIPTION
Frames previously were not properly repeating. This PR should fix that. Tested with the following js program

```js
CanBridge.sendCANMessage(descriptor, 0xCBA321, [0x12, 0x34, 0x56, 0x78], 150)

await new Promise((resolve) => setTimeout(resolve, 2000));

CanBridge.sendCANMessage(descriptor, 0xCBA321, [0x34, 0x56, 0x78, 0x12], 150)

await new Promise((resolve) => setTimeout(resolve, 2000));

CanBridge.sendCANMessage(descriptor, 0xCBA321, [0x34, 0x56, 0x78, 0x12], 100)

await new Promise((resolve) => setTimeout(resolve, 2000));

CanBridge.sendCANMessage(descriptor, 0xCBA321, [0x34, 0x56, 0x78, 0x12], 0)

```