### PR TITLE
Allow multiple messages to be scheduled with the same ID if the interval is set to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ new call with different data is sent before the previous
 interval is up. Sending a frame with an interval of -1
 will cancel the repeat, and not send the frame. Sending with
 an interval of 0 will schedule the new frame once, then stop
-repeating. Unlike with a positive interval, and interval of 0 
+repeating. Unlike with a positive interval, an interval of 0 
 guarantees that each new message will be sent.
 
 ## Build Requirements

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ new call with different data is sent before the previous
 interval is up. Sending a frame with an interval of -1
 will cancel the repeat, and not send the frame. Sending with
 an interval of 0 will schedule the new frame once, then stop
-repeating.
+repeating. Unlike with a positive interval, and interval of 0 
+guarantees that each new message will be sent.
 
 ## Build Requirements
 

--- a/src/main/native/include/rev/Drivers/DriverDeviceThread.h
+++ b/src/main/native/include/rev/Drivers/DriverDeviceThread.h
@@ -103,6 +103,12 @@ public:
         if(timeIntervalMs == 0) {
             // If the time interval is 0, we want to allow duplicates.
             m_sendQueue.push_back(detail::CANThreadSendQueueElement(msg, timeIntervalMs));
+
+            // Cancel existing repeating frame with same id
+            detail::CANThreadSendQueueElement* existing = findFirstMatchingIdWithNonZeroInterval(msg.GetMessageId());
+            if(existing) {
+                existing->m_intervalMs = -1;
+            }
         } else {
             // We don't want to replace elements with zero as the interval. Those should be guaranteed to be sent
             detail::CANThreadSendQueueElement* existing = findFirstMatchingIdWithNonZeroInterval(msg.GetMessageId());

--- a/src/main/native/include/rev/Drivers/DriverDeviceThread.h
+++ b/src/main/native/include/rev/Drivers/DriverDeviceThread.h
@@ -75,15 +75,6 @@ public:
         }
     }
 
-    detail::CANThreadSendQueueElement* findFirstMatchingId(int targetId) {
-        for (auto& element : m_sendQueue) {
-            if (element.m_msg.GetMessageId() == targetId) {
-                return &element;
-            }
-        }
-        return nullptr; // If no matching element found
-    }
-
     detail::CANThreadSendQueueElement* findFirstMatchingIdWithNonZeroInterval(int targetId) {
         for (auto& element : m_sendQueue) {
             if (element.m_msg.GetMessageId() == targetId && element.m_intervalMs > 0) {


### PR DESCRIPTION
Our current contract for the interval is as follows:

- -1 -> Stop a repeated frame. Do not send the last data frame
- 0 -> Send this data once. Cancel any repeating frames with the same ID.
- \> 0 -> Send data on repeat with a period in milliseconds. If called again with period > 0 and new data, update the data in the periodic message

A caller that provides 0 multiple times can reasonably assume that every message is sent, but this was not the case previously. Only one message could be scheduled at a time with a given ID.
