### PR TITLE
Disable caching in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,17 +37,6 @@ jobs:
           distribution: 'zulu'
           java-version: 11
 
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            .gradle
-            bin
-            build
-          key: ${{ matrix.name }}-build-${{ github.sha }}
-          restore-keys: |
-            ${{ matrix.name }}-build-
-
       - name: Build
         run: |
           ./gradlew outputVersions publish ${{ matrix.build-options }} -PreleaseMode


### PR DESCRIPTION
The Post Cache step was somehow taking more than 2 minutes