### PR TITLE
Allow sending RTR messages

### DIFF
--- a/src/main/native/include/rev/CANMessage.h
+++ b/src/main/native/include/rev/CANMessage.h
@@ -180,7 +180,6 @@ private:
     uint8_t m_size;
     uint32_t m_messageId;
     uint32_t m_timestamp;
-    bool m_is_remote;
     bool m_isNew{true};
 };
 

--- a/src/main/native/include/rev/CANMessage.h
+++ b/src/main/native/include/rev/CANMessage.h
@@ -38,6 +38,7 @@
 
 #define EXTENDED_ID_MASK 0x40000000
 #define REMOTE_FRAME_MASK 0x80000000
+#define NON_RESERVED_ARB_ID_MASK 0x1FFFFFFF
 
 namespace rev {
 namespace usb {

--- a/src/main/native/include/rev/CANMessage.h
+++ b/src/main/native/include/rev/CANMessage.h
@@ -36,6 +36,9 @@
 #include <iostream>
 #include <chrono>
 
+#define EXTENDED_ID_MASK 0x40000000
+#define REMOTE_FRAME_MASK 0x80000000
+
 namespace rev {
 namespace usb {
 
@@ -178,6 +181,7 @@ private:
     uint8_t m_size;
     uint32_t m_messageId;
     uint32_t m_timestamp;
+    bool m_is_remote;
     bool m_isNew{true};
 };
 

--- a/src/main/native/include/rev/CANMessage.h
+++ b/src/main/native/include/rev/CANMessage.h
@@ -36,8 +36,6 @@
 #include <iostream>
 #include <chrono>
 
-#define EXTENDED_ID_MASK 0x40000000
-#define REMOTE_FRAME_MASK 0x80000000
 #define NON_RESERVED_ARB_ID_MASK 0x1FFFFFFF
 
 namespace rev {

--- a/src/main/native/include/rev/Drivers/CandleWinUSB/CandleWinUSBDeviceThread.h
+++ b/src/main/native/include/rev/Drivers/CandleWinUSB/CandleWinUSBDeviceThread.h
@@ -173,7 +173,7 @@ private:
             candle_frame_t frame;
             frame.can_dlc = el.m_msg.GetSize();
 
-            uint32_t messageId = el.m_msg.GetMessageId();
+            uint32_t messageId = el.m_msg.GetMessageId() & NON_RESERVED_ARB_ID_MASK;
 
             bool isExtended = true; // FRC CAN is always extended
             bool isRtr = messageId & REMOTE_FRAME_MASK;

--- a/src/main/native/include/rev/Drivers/CandleWinUSB/CandleWinUSBDeviceThread.h
+++ b/src/main/native/include/rev/Drivers/CandleWinUSB/CandleWinUSBDeviceThread.h
@@ -176,7 +176,7 @@ private:
             uint32_t messageId = el.m_msg.GetMessageId() & NON_RESERVED_ARB_ID_MASK;
 
             bool isExtended = true; // FRC CAN is always extended
-            bool isRtr = messageId & REMOTE_FRAME_MASK;
+            bool isRtr = messageId & HAL_CAN_IS_FRAME_REMOTE;
 
             frame.can_id = messageId;
             if(isExtended) {

--- a/src/main/native/include/rev/Drivers/CandleWinUSB/CandleWinUSBDeviceThread.h
+++ b/src/main/native/include/rev/Drivers/CandleWinUSB/CandleWinUSBDeviceThread.h
@@ -53,6 +53,9 @@
 #include <hal/simulation/CanData.h>
 #include <hal/CAN.h>
 
+#define CANDLE_EXTENDED_ID_MASK 0x80000000
+#define CANDLE_REMOTE_FRAME_MASK 0x40000000
+
 namespace rev {
 namespace usb {
 
@@ -169,8 +172,20 @@ private:
         if (el.m_intervalMs <= 1 || (now - el.m_prevTimestamp >= std::chrono::milliseconds(el.m_intervalMs)) ) {
             candle_frame_t frame;
             frame.can_dlc = el.m_msg.GetSize();
-            // set extended id flag
-            frame.can_id = el.m_msg.GetMessageId() | 0x80000000;
+
+            uint32_t messageId = el.m_msg.GetMessageId();
+
+            bool isExtended = true; // FRC CAN is always extended
+            bool isRtr = messageId & REMOTE_FRAME_MASK;
+
+            frame.can_id = messageId;
+            if(isExtended) {
+            	frame.can_id |= CANDLE_EXTENDED_ID_MASK;
+            }
+            if(isRtr) {
+                frame.can_id |= CANDLE_REMOTE_FRAME_MASK;
+            }
+
             memcpy(frame.data, el.m_msg.GetData(), frame.can_dlc);
             frame.timestamp_us = now.time_since_epoch().count() / 1000;
 


### PR DESCRIPTION
We use the mask `0x80000000`, like WPILib for specifying RTR. Note that Candlelib uses `0x40000000` to mean RTR, so we have to translate.