### PR TITLE
Check non-masked message ID

### DIFF
--- a/src/main/native/include/rev/Drivers/CandleWinUSB/CandleWinUSBDeviceThread.h
+++ b/src/main/native/include/rev/Drivers/CandleWinUSB/CandleWinUSBDeviceThread.h
@@ -176,7 +176,7 @@ private:
             uint32_t messageId = el.m_msg.GetMessageId() & NON_RESERVED_ARB_ID_MASK;
 
             bool isExtended = true; // FRC CAN is always extended
-            bool isRtr = messageId & HAL_CAN_IS_FRAME_REMOTE;
+            bool isRtr = el.m_msg.GetMessageId() & HAL_CAN_IS_FRAME_REMOTE;
 
             frame.can_id = messageId;
             if(isExtended) {


### PR DESCRIPTION
We originally masked out the bit we were about to check.