### PR TITLE
Enforce that CANMessage.m_dataSize won't be larger than 8 bytes

### DIFF
--- a/src/main/native/cpp/Drivers/CandleWinUSB/CandleWinUSBDevice.cpp
+++ b/src/main/native/cpp/Drivers/CandleWinUSB/CandleWinUSBDevice.cpp
@@ -131,7 +131,7 @@ CANStatus CandleWinUSBDevice::ReceiveCANMessage(std::shared_ptr<CANMessage>& msg
     // Assume timeout
     CANStatus status = CANStatus::kTimeout;
 
-    // parse through the keys, find the messges the match, and return it
+    // parse through the keys, find the messages that match, and return it
     // The first in the message id, then the messages
     std::map<uint32_t, std::shared_ptr<CANMessage>> messages;
     m_thread.ReceiveMessage(messages);

--- a/src/main/native/include/rev/CANMessage.h
+++ b/src/main/native/include/rev/CANMessage.h
@@ -78,11 +78,12 @@ class CANMessage {
 public:
     CANMessage() : m_data{0}, m_size(0), m_messageId(0) { }
     CANMessage(uint32_t messageId, const uint8_t* data, uint8_t dataSize, uint32_t timestampUs = 0) :
-        m_size(dataSize), m_messageId(messageId) {
-
+        m_messageId(messageId) {
+            // TODO: Support CAN FD
+            m_dataSize = dataSize > 8 ? 8 : dataSize
             m_timestamp = (timestampUs != 0) ? timestampUs : std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now()).time_since_epoch().count();
             std::memset(m_data, 0, 8);
-            std::memcpy(m_data, data, dataSize > 8 ? 8 : dataSize);
+            std::memcpy(m_data, data, m_dataSize);
     }
 
     ~CANMessage() = default;


### PR DESCRIPTION
Previously, the actual data array in `CANMessage` was always limited to 8 bytes, but `m_dataSize` could be larger than that, which could trick consumers of this library into reading from an invalid memory location.

Marking this as a draft, because I think `CandleWinUsbDeviceThread` suffers from a similar issue. The `data` field on `candle_frame_t` (which represents the actual format of the USB packet) always has a length of `8`, but it's possible for the `dlc` sent over CAN to be higher than that. This line of code should not assume that `frame.data` is at least as large as `frame.can_dlc`:

https://github.com/REVrobotics/CANBridge/blob/8d0f4f64e787f983a238685f3bad5c310530ef8a/src/main/native/include/rev/Drivers/CandleWinUSB/CandleWinUSBDeviceThread.h#L189